### PR TITLE
add status select option

### DIFF
--- a/src/WC_Gateway_ThawaniGateway.php
+++ b/src/WC_Gateway_ThawaniGateway.php
@@ -219,7 +219,7 @@ class WC_Gateway_ThawaniGateway extends \WC_Payment_Gateway
         $order = wc_get_order($order_id);
         $order_thanks_page = $this->get_return_url($order);
 
-        $order->update_status('wc-processing', __('payment Success', 'thawani'));
+        $order->update_status('wc-'.$this->order_status, __('payment Success', 'thawani'));
 
         wp_redirect($order_thanks_page);
         exit;

--- a/src/WC_Gateway_ThawaniGateway.php
+++ b/src/WC_Gateway_ThawaniGateway.php
@@ -281,6 +281,8 @@ class WC_Gateway_ThawaniGateway extends \WC_Payment_Gateway
                     'processing' => __('processing' , 'thawani'),
                     'completed' => __('completed', 'thawani'),
                 ),
+                'description' => __('This is the status that your order will be in after payment is completed', 'thawani'),
+                'desc_tip' => true,
             ),'environment' => array(
                 'title' => __('Select the environment', 'thawani'),
                 'type' => 'select',

--- a/src/WC_Gateway_ThawaniGateway.php
+++ b/src/WC_Gateway_ThawaniGateway.php
@@ -269,7 +269,14 @@ class WC_Gateway_ThawaniGateway extends \WC_Payment_Gateway
             //     'description' => '',
             //     'default' => 'no',
             // ),
-            'environment' => array(
+            'status' => array(
+                'title' => __('Select complete order status', 'thawani'),
+                'type' => 'select',
+                'options' => array(
+                    'processing' => __('processing' , 'thawani'),
+                    'completed' => __('completed', 'thawani'),
+                ),
+            ),'environment' => array(
                 'title' => __('Select the environment', 'thawani'),
                 'type' => 'select',
                 'options' => array(

--- a/src/WC_Gateway_ThawaniGateway.php
+++ b/src/WC_Gateway_ThawaniGateway.php
@@ -27,6 +27,10 @@ class WC_Gateway_ThawaniGateway extends \WC_Payment_Gateway
      **/
     protected $publishable_key;
     /**
+     * @var string Success order status
+     */
+    protected $order_status;
+    /**
      * @var string The environment holder of the plugin
      */
     protected $environment;
@@ -67,6 +71,7 @@ class WC_Gateway_ThawaniGateway extends \WC_Payment_Gateway
         $this->secret_key = $this->get_option('secret_key');
         $this->publishable_key = $this->get_option('publishable_key');
         $this->environment = $this->get_option('environment');
+        $this->order_status = $this->get_option('status');
         self::$log_enabled = ($this->get_option('debug') == "yes") ? true: false;
         // disabled for now -- may updated later to enable this feature 
         // $this->is_save_cards = $this->get_option('save_cards');


### PR DESCRIPTION
# closes #66 

Allowing the store manager to set the default order status on a success checkout 
This feature will be helpful for stores that only sells virtual products

## Description:

#### UI 


<img width="798" alt="Screen Shot 2021-11-13 at 11 49 00 AM" src="https://user-images.githubusercontent.com/60617324/141610709-a7e1c066-a227-4571-a1e8-b288f020c0dc.png">

<img width="1263" alt="Screen Shot 2021-11-13 at 11 48 18 AM" src="https://user-images.githubusercontent.com/60617324/141610705-63357d65-6bbd-470b-a7a0-67f0183eeedd.png">


#### Tooltip as suggested by @Ma7eer 

<img width="640" alt="Screen Shot 2021-11-13 at 7 00 22 PM" src="https://user-images.githubusercontent.com/60617324/141648624-7eeb8a99-9df9-4b3b-a0ab-e50ae276df4d.png">



## Testing:

N/A

## Checklist

- [ ] I have commented the newly added code
- [ ] I update the Readme.md file to include the new changes to the project
- [ ] All the previously included Unit Tests passed in all the cases
