### PR TITLE
Add stale .github workflow

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -9,7 +9,7 @@ daysUntilClose: 1
 # Issues or Pull Requests with these labels will never be considered stale. Set to `[]` to disable
 exemptLabels:
   - bug
-  - Bug(Potintail)
+  - Bug(Potential)
   - chore
   - documentation
   - "help wanted"

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,42 @@
+
+# Number of days of inactivity before an Issue or Pull Request becomes stale
+daysUntilStale: 3
+
+# Number of days of inactivity before an Issue or Pull Request with the stale label is closed.
+# Set to false to disable. If disabled, issues still need to be closed manually, but will remain marked as stale.
+daysUntilClose: 1
+
+# Issues or Pull Requests with these labels will never be considered stale. Set to `[]` to disable
+exemptLabels:
+  - bug
+  - Bug(Potintail)
+  - chore
+  - documentation
+  - "help wanted"
+  - "good first issue"
+  - enhancement
+
+# Set to true to ignore issues in a project (defaults to false)
+exemptProjects: false
+
+# Set to true to ignore issues in a milestone (defaults to false)
+exemptMilestones: false
+
+# Set to true to ignore issues with an assignee (defaults to false)
+exemptAssignees: false
+
+# Label to use when marking as stale
+staleLabel: wontfix
+
+# Comment to post when marking as stale. Set to `false` to disable
+markComment: >
+  This issue has been automatically marked as stale because it has not had
+  recent activity. It will be closed if no further activity occurs. Thank you
+  for your contributions.
+
+# Comment to post when removing the stale label.
+# unmarkComment: >
+#   Your comment here.
+
+# Limit to only `issues` or `pulls`
+only: issues


### PR DESCRIPTION
# Issue Addressed 
Discussed in #84 

The bot is added but the implementation is missing 

## Description:

More about stale bot https://github.com/probot/stale

## Testing:

N/A

## Checklist

- [x] I have commented the newly added code
- [ ] I update the Readme.md file to include the new changes to the project
- [ ] All the previously included Unit Tests passed in all the cases
