### PR TITLE
Fix: Round up the product price

### DIFF
--- a/src/WC_Gateway_ThawaniGateway.php
+++ b/src/WC_Gateway_ThawaniGateway.php
@@ -351,7 +351,7 @@ class WC_Gateway_ThawaniGateway extends \WC_Payment_Gateway
                 $product_name = mb_substr($product_name, 0, 30, 'UTF-8') . '...';
             $products[] = [
                 'name' => $product_name,
-                'unit_amount' => ($unit_price / (int) $item->get_data()['quantity']),
+                'unit_amount' => (int)ceil(($unit_price / (int) $item->get_data()['quantity'])),
                 'quantity' => $item->get_data()['quantity'],
             ];
         }


### PR DESCRIPTION
closes #86 

## Description:

it was when the product has a fraction and there was no casting / converting it back to integer is breaking the size limit before sending it back to Thawani session creation. 


### before 

#### Without **Tax** enabled
https://user-images.githubusercontent.com/60617324/169587382-b3aa86f4-d0d0-4853-9f7d-337924f4b0aa.mp4

#### With **Tax** enabled

https://user-images.githubusercontent.com/60617324/169588650-5474baa7-99ec-4063-94b1-c8d7a976ddc8.mp4



### after 


https://user-images.githubusercontent.com/60617324/169588964-caadaafa-9a4d-45be-bd2c-7cfcb4603c5a.mp4



## Testing:
N/A
## Checklist

- [ ] I have commented the newly added code
- [ ] I update the Readme.md file to include the new changes to the project
- [ ] All the previously included Unit Tests passed in all the cases
