### PR TITLE
Update WC_Gateway_ThawaniGateway.php

### DIFF
--- a/src/WC_Gateway_ThawaniGateway.php
+++ b/src/WC_Gateway_ThawaniGateway.php
@@ -341,6 +341,11 @@ class WC_Gateway_ThawaniGateway extends \WC_Payment_Gateway
         foreach ($items as $item) {
             $product_price  = (float) $item->get_data()['total'];
 
+            // skip items with zero price (Free/Gift Products) to avoid error when order is placed
+            if ($product_price <= 0) {
+                continue;
+            }
+
             if ((float)$tax > 0)
                 $unit_price = $this->format_price($product_price + ($product_price * ($tax / 100)));
             else


### PR DESCRIPTION
Skip items with zero price (Free/Gift Products) to avoid error when order is placed

# Issue Addressed ("Issue ID"):

We sometimes offer Free Products for customers based on total cart or copoun ,
Customers who are using Thawani to complete the payment are getting the followin error
“There was an error processing your order. Please check for any charges in your payment method and review your order history before placing the order again.”

To Reproduce
Steps to reproduce the behavior:
1- Add Multiple products to cart
2 - Add one or more 0 Priced / Free Product to cart
3 - Place order on checkout page
4 - Error

Expected behavior
The order should be processed like any other payment gateway

## Description:
Added the following code to prepare_products fuction to skip items with zero price (Free/Gift Products) to avoid error when order is placed

            if ($product_price <= 0) {
                continue;
            }

## Testing:

- I was able to place the order without any error after modification

